### PR TITLE
Patch checluster CR gitservices, create 1-scc-privileges.sh

### DIFF
--- a/0-configure-gh-oauth.sh
+++ b/0-configure-gh-oauth.sh
@@ -1,16 +1,22 @@
+#!/bin/bash
+
+createOAuthSecret() {
 cat << EOF | kubectl apply -f -
   kind: Secret
   apiVersion: v1
   metadata:
     name: github-oauth-config
     namespace: openshift-devspaces
-    labels:
-      app.kubernetes.io/part-of: che.eclipse.org
-      app.kubernetes.io/component: oauth-scm-configuration
-    annotations:
-      che.eclipse.org/oauth-scm-server: github
   type: Opaque
   data:
     id: ${BASE64_GH_OAUTH_CLIENT_ID}
     secret: ${BASE64_GH_OAUTH_CLIENT_SECRET}
 EOF
+}
+
+setOAuthSecret() {
+  kubectl patch checluster devspaces --type=merge -p '{"spec":{"gitServices":{"github":[{"endpoint":"https://github.com","secretName":"github-oauth-config"}]}}}' -n openshift-devspaces
+}
+
+createOAuthSecret
+setOAuthSecret

--- a/1-scc-privileges.sh
+++ b/1-scc-privileges.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Create SCC
+kubectl apply -f - <<EOF
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: container-build
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - SETUID
+  - SETGID
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+# Temporary workaround for https://github.com/devfile/devworkspace-operator/issues/884
+priority: 20
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+groups: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+EOF
+
+# Create the cluster role get-n-update-container-build-scc
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: get-n-update-container-build-scc
+rules:
+- apiGroups:
+  - "security.openshift.io"
+  resources:
+  - "securitycontextconstraints"
+  resourceNames:
+  - "container-build"
+  verbs:
+  - "get"
+  - "update"
+EOF
+
+# Add the role to the DevWorkspace controller Service Account
+oc adm policy add-cluster-role-to-user \
+       get-n-update-container-build-scc \
+       system:serviceaccount:openshift-operators:devworkspace-controller-serviceaccount
+
+oc adm policy add-scc-to-user container-build ${OPENSHIFT_USER}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ $ ./0-configure-gh-oauth.sh
 # This is optional
 ```
 
+### Configure SCC and privileges for Podman build
+```bash
+export OPENSHIFT_USER=<your-username>
+$ ./1-scc-privileges.sh
+```
+
+### Set the default editor to VS Code
+```bash
+kubectl patch checluster devspaces --type=merge -p '{"spec":{"devEnvironments":{"defaultEditor":"che-incubator/che-code/insiders"}}}' -n openshift-devspaces
+```
+
 # Run the demo
 
 ## STEP 1 - Start an IDE with a link (and show the power of URL parameters)


### PR DESCRIPTION
1-scc-priveleges.sh content from: https://github.com/l0rd/che-blog/blob/f7ddb302b11997d4bd69b68642f494b5016cf07b/_posts/2022-09-27-building-container-images.adoc

Signed-off-by: David Kwon <dakwon@redhat.com>