### PR TITLE
Add git submodule update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 
 ```bash
 # STEP 0: Install Dev Spaces next
+git submodule update --init &&
 git -C devspaces checkout devspaces-3-rhel-8 &&
 cd devspaces/product &&
 ./installDevSpacesFromLatestIIB.sh --next


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Forgot to provide this feedback for this PR: https://github.com/che-incubator/devspaces-demo/pull/4. When the workspace starts, the submodule is not cloned. The `git submodule update` command clones the missing submodule

Related issue: https://github.com/devfile/devworkspace-operator/issues/949