### PR TITLE
Edit identityProvider patch and update quotas LimitRange exists

### DIFF
--- a/1-create-unprivileged-user.sh
+++ b/1-create-unprivileged-user.sh
@@ -19,13 +19,17 @@ data:
   htpasswd: ${htpwd_encoded}
 EOF
 
-kubectl patch oauths cluster --type merge -p '
-spec:
-  identityProviders:
-    - name: htpasswd
-      mappingMethod: claim
-      type: HTPasswd
-      htpasswd:
-        fileData:
-          name: htpass-secret
-'
+kubectl patch oauth cluster --type='json' -p '[
+  {
+    "op":"add","path":"/spec/identityProviders/1",
+    "value":{
+      "name":"htpasswd",
+      "mappingMethod":"claim",
+      "type":"HTPasswd",
+      "htpasswd":
+        {"fileData":
+          {"name":"htpass-secret"}
+        }
+    }
+  }
+]'

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ export UDI_IMAGE="quay.io/devspaces/udi-rhel8:3.3"
 ./patch-dw-subcription.sh
 ```
 
+Depending on the cluster setup, if a `LimitRange` exists in the user namespace, you may have to adjust user namespace resource quotas to start workspaces with VS Code and IntelliJ:
+
+```
+export USER_NAMESPACE="USER NAMESPACE HERE"
+./increase-namepsace-quotas.sh
+```
+
 # Run the demo
 
 For STEP 3 and STEP 4, this [demo microservice project](https://github.com/dkwon17/quarkus-api-example/tree/devspaces) can be forked and used. When forking, confirm that the `devspaces` branch is copied to the fork.

--- a/increase-resource-range.sh
+++ b/increase-resource-range.sh
@@ -9,7 +9,7 @@ fi
 
 # Set container and pod memory limit to NEW_LIMIT
 NEW_LIMIT="16Gi"
-N_LIMIT_RANGE=$(kubectl get limits -n opentlc-mgr-che --no-headers | wc -l)
+N_LIMIT_RANGE=$(kubectl get limits -n $USER_NAMESPACE --no-headers | wc -l)
 
 if [[ $N_LIMIT_RANGE -eq 0 ]]; then
   echo "There are no LimitRanges."
@@ -21,7 +21,7 @@ if [[ $N_LIMIT_RANGE -gt 1 ]]; then
   exit 0
 fi
 
-LIMIT_RANGE=$(kubectl get limits -n opentlc-mgr-che --no-headers -o custom-columns=":metadata.name")
+LIMIT_RANGE=$(kubectl get limits -n $USER_NAMESPACE --no-headers -o custom-columns=":metadata.name")
 
 PATCH="{\"spec\":{\"limits\":[{\"type\":\"Container\",\"max\":{\"cpu\":\"4\",\"memory\":\"${NEW_LIMIT}\"}},{\"type\":\"Pod\",\"max\":{\"cpu\":\"4\",\"memory\":\"${NEW_LIMIT}\"}}]}}"
 

--- a/increase-resource-range.sh
+++ b/increase-resource-range.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+if [[ -z $USER_NAMESPACE ]]; then
+  echo "Error: USER_NAMESPACE is not set"
+  exit 1
+fi
+
+# Set container and pod memory limit to NEW_LIMIT
+NEW_LIMIT="16Gi"
+N_LIMIT_RANGE=$(kubectl get limits -n opentlc-mgr-che --no-headers | wc -l)
+
+if [[ $N_LIMIT_RANGE -eq 0 ]]; then
+  echo "There are no LimitRanges."
+  exit 0
+fi
+
+if [[ $N_LIMIT_RANGE -gt 1 ]]; then
+  echo "There are ${N_LIMIT_RANGE} LimitRanges in $USER_NAMESPACE, unclear which to edit. Please increase container and pod memory limit to ${NEW_LIMIT} manually."
+  exit 0
+fi
+
+LIMIT_RANGE=$(kubectl get limits -n opentlc-mgr-che --no-headers -o custom-columns=":metadata.name")
+
+PATCH="{\"spec\":{\"limits\":[{\"type\":\"Container\",\"max\":{\"cpu\":\"4\",\"memory\":\"${NEW_LIMIT}\"}},{\"type\":\"Pod\",\"max\":{\"cpu\":\"4\",\"memory\":\"${NEW_LIMIT}\"}}]}}"
+
+kubectl patch LimitRange $LIMIT_RANGE \
+  --type=merge -p \
+  "${PATCH}" \
+  -n $USER_NAMESPACE


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

The identityProvider patch was replacing the current identityProvider for some reason, this PR edits the patch to only add it instead.

PR also introduces an optional script that increases the user namespace's memory quotas for container and pods. This is because some clusters may have a [default project template](https://docs.openshift.com/container-platform/4.6/applications/projects/configuring-project-creation.html) already set up with LimitRanges defined for new namespaces.