### PR TITLE
chore: Update README.md: added two admonitions to explain how to use --latest and how to re-enable default operatorhub sources when installing with --next.  Also noted that you can use the -os and -kp flags to install using kubeadmin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,8 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 ```bash
 # STEP 1: Install Dev Spaces next
 git submodule init && git submodule update && git -C devspaces checkout devspaces-3-rhel-8 &&
-cd devspaces/product && ./installDevSpacesFromLatestIIB.sh --next
-```
-
-| :steam_locomotive: NOTE 1     |
-|-------------------------------------------------------------------------------------------------------|
-| Using `--next` will disable default catalog sources, but you can re-enable them after installation with the following command:
-`oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]'`|
+cd devspaces/product && ./installDevSpacesFromLatestIIB.sh --next && \
+oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]' # re-enable default catalog sources
 
 | :ship: NOTE                                                                                        |
 |-------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 
 | :warning: WARNING                                                                                     |
 |-------------------------------------------------------------------------------------------------------|
-| Run `oc login` as an administrator on the target OpenShift cluster before running the following steps, or use the `--kubepwd` and `--openshift` flags to log in as kubeadmin automatically.|
+| Run `oc login` as an administrator on the target OpenShift cluster before running the following steps.|
 
 ```bash
 # STEP 1: Install Dev Spaces next

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd devspaces/product && ./installDevSpacesFromLatestIIB.sh --next
 | Using `--next` will disable default catalog sources, but you can re-enable them after installation with the following command:
 `oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]'`|
 
-| :ship: NOTE 2                                                                                        |
+| :ship: NOTE                                                                                        |
 |-------------------------------------------------------------------------------------------------------|
 | If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `./installDevSpacesFromLatestIIB.sh --latest`.|
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 
 | :warning: WARNING                                                                                     |
 |-------------------------------------------------------------------------------------------------------|
-| Run `oc login` as an administrator on the target OpenShift cluster before running the following steps.|
-
-
+| Run `oc login` as an administrator on the target OpenShift cluster before running the following steps, or use the `--kubepwd` and `--openshift` flags to log in as kubeadmin automatically.|
 
 ```bash
 # STEP 1: Install Dev Spaces next
 git submodule init && git submodule update && git -C devspaces checkout devspaces-3-rhel-8 &&
 cd devspaces/product && ./installDevSpacesFromLatestIIB.sh --next
+```
 
+| :steam_locomotive: NOTE 1     |
+|-------------------------------------------------------------------------------------------------------|
+| Using `--next` will disable default catalog sources, but you can re-enable them after installation with the following command:
+`oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]'`|
+
+| :ship: NOTE 2                                                                                        |
+|-------------------------------------------------------------------------------------------------------|
+| If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `./installDevSpacesFromLatestIIB.sh --latest`.|
+
+```bash
 # STEP 2: Day one configurations
 # Create OpenShift unprivileged user (can be skipped if such a user already exist) 
 ./1-create-unprivileged-user.sh


### PR DESCRIPTION
see screenshot: added two admonitions to explain how to use `--latest` and how to re-enable default operatorhub sources when installing with `--next`.

Also noted that you can use the `-os` and `-kp` flags to install using kubeadmin login