### PR TITLE
Update how oauth cluster is patched

### DIFF
--- a/1-create-unprivileged-user.sh
+++ b/1-create-unprivileged-user.sh
@@ -19,20 +19,20 @@ data:
   htpasswd: ${htpwd_encoded}
 EOF
 
-kubectl patch oauth cluster --type='json' -p '[
-  {
-    "op":"add","path":"/spec",
-    "value":{
-      "identityProviders": [
-         {  "name":"htpasswd",
-            "mappingMethod":"claim",
-            "type":"HTPasswd",
-            "htpasswd":
-            { "fileData":
-               { "name":"htpass-secret"}
-            }
-         }
-      ]
-    }
-  }
-]'
+IP_NAME=devspaces-demo
+kubectl get oauths cluster -o json | \
+  jq 'if .spec.identityProviders and (.spec.identityProviders|any(.name == "'"$IP_NAME"'")) 
+    then . 
+    else .spec.identityProviders += [{
+      "name":"'"$IP_NAME"'",
+      "mappingMethod":"claim",
+      "type":"HTPasswd",
+      "htpasswd":{
+        "fileData":{
+          "name":"htpass-secret"
+        }
+      }
+    }]
+    end' | \
+  kubectl apply -f -
+

--- a/1-create-unprivileged-user.sh
+++ b/1-create-unprivileged-user.sh
@@ -21,15 +21,18 @@ EOF
 
 kubectl patch oauth cluster --type='json' -p '[
   {
-    "op":"add","path":"/spec/identityProviders/1",
+    "op":"add","path":"/spec",
     "value":{
-      "name":"htpasswd",
-      "mappingMethod":"claim",
-      "type":"HTPasswd",
-      "htpasswd":
-        {"fileData":
-          {"name":"htpass-secret"}
-        }
+      "identityProviders": [
+         {  "name":"htpasswd",
+            "mappingMethod":"claim",
+            "type":"HTPasswd",
+            "htpasswd":
+            { "fileData":
+               { "name":"htpass-secret"}
+            }
+         }
+      ]
     }
   }
 ]'


### PR DESCRIPTION
On OCP 4.12 the script failed to patch `oauth cluster` with message

```
The request is invalid: the server rejected our request due to an error in our request
``` 

This new patch fixes that.