### PR TITLE
Use dsc to install Dev Spaces

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -8,15 +8,24 @@ components:
       memoryRequest: 256M
       memoryLimit: 1536M
       cpuRequest: 100m
-      cpuLimit: 500m
+      cpuLimit: 1500m
 commands:
   - id: 1-deploy-devspaces
     exec:
       label: "1. Deploy nightly build of Dev Spaces"
       component: tooling-container
-      commandLine: | 
+      commandLine: |
         [[ "$(oc whoami)" =~ ^kube:admin$ ]] || (echo "You need to login as kubeadmin" && false) &&
-        dsc server:deploy --olm-channel=fast
+        DSC_VERSION="3.5.0-CI"; DSC_ARCH="linux-x64"
+        DSC_HOME=${HOME}/.dsc; mkdir -p "${DSC_HOME}"
+        DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-dsc-assets/devspaces-${DSC_VERSION%-*}-dsc-${DSC_ARCH}.tar.gz"
+        curl -sSkLo- "${DSC_TGZ_URL}" | tar -zx -C "${DSC_HOME}/" --strip-components 1 
+        if [[ -d ${DSC_HOME}/bin ]]; then \
+          export PATH=${PATH%":${DSC_HOME}/bin"}:${DSC_HOME}/bin; echo -n "Installed: "; dsc version; \
+        else \
+          echo "An error occurred installing dsc $DSC_VERSION for arch $DSC_ARCH ! Check if ${DSC_TGZ_URL} is a valid file."; \
+        fi
+        dsc server:deploy --olm-channel=next --telemetry=off
   - id: 2-day1-configs
     exec:
       label: "2. Create users, change inactivity timeout and enable container build capabilities, GitHub OAuth and image puller"

--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -16,10 +16,7 @@ commands:
       component: tooling-container
       commandLine: | 
         [[ "$(oc whoami)" =~ ^kube:admin$ ]] || (echo "You need to login as kubeadmin" && false) &&
-        git submodule init && git submodule update && \
-        git -C devspaces checkout devspaces-3-rhel-8 && \
-        cd devspaces/product && \
-        ./installDevSpacesFromLatestIIB.sh --next
+        dsc server:deploy --olm-channel=fast
   - id: 2-day1-configs
     exec:
       label: "2. Create users, change inactivity timeout and enable container build capabilities, GitHub OAuth and image puller"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "devspaces"]
-	path = devspaces
-	url = https://github.com/redhat-developer/devspaces

--- a/README.md
+++ b/README.md
@@ -16,20 +16,15 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 
 ```bash
 # STEP 1: Install Dev Spaces next
-DSC_HOME=/home/user/.dsc
-TEMP_DIR="$(mktemp -d)"
-DSC_VERSION="3.5.0"
-DSC_ARCH="linux-x64"
-DSC_TGZ="devspaces-${DSC_VERSION}-dsc-${DSC_ARCH}.tar.gz"
-DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-CI-dsc-assets/${DSC_TGZ}"
-
-cd "${TEMP_DIR}"
-curl -sSLO "${DSC_TGZ_URL}"
-tar -zxvf "${DSC_TGZ}"
-mv dsc "${DSC_HOME}"
-PATH=${PATH}:${DSC_HOME}/bin
-rm "${DSC_TGZ}"
-cd -
+DSC_VERSION="3.5.0-CI"; DSC_ARCH="linux-x64"
+DSC_HOME=${HOME}/.dsc; mkdir -p "${DSC_HOME}"
+DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-dsc-assets/devspaces-${DSC_VERSION%-*}-dsc-${DSC_ARCH}.tar.gz"
+curl -sSkLo- "${DSC_TGZ_URL}" | tar -zx -C "${DSC_HOME}/" --strip-components 1 
+if [[ -d ${DSC_HOME}/bin ]]; then \
+  export PATH=${PATH%":${DSC_HOME}/bin"}:${DSC_HOME}/bin; echo -n "Installed: "; dsc version; \
+else \
+  echo "An error occurred installing dsc $DSC_VERSION for arch $DSC_ARCH ! Check if ${DSC_TGZ_URL} is a valid file."; \
+fi
 
 dsc server:deploy --olm-channel=next
 ```

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 # STEP 1: Install Dev Spaces next
 DSC_HOME=/home/user/.dsc
 TEMP_DIR="$(mktemp -d)"
-DSC_VERSION="3.4.0"
+DSC_VERSION="3.5.0"
 DSC_ARCH="linux-x64"
 DSC_TGZ="devspaces-${DSC_VERSION}-dsc-${DSC_ARCH}.tar.gz"
-DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-GA-dsc-assets/${DSC_TGZ}"
+DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-CI-dsc-assets/${DSC_TGZ}"
 
 cd "${TEMP_DIR}"
 curl -sSLO "${DSC_TGZ_URL}"
@@ -31,12 +31,12 @@ PATH=${PATH}:${DSC_HOME}/bin
 rm "${DSC_TGZ}"
 cd -
 
-dsc server:deploy --olm-channel=fast
+dsc server:deploy --olm-channel=next
 ```
 
 | :ship: NOTE                                                                                        |
 |-------------------------------------------------------------------------------------------------------|
-| If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `dsc server:deploy`.|
+| If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `dsc server:deploy --olm-channel=latest'.|
 
 ```bash
 # STEP 2: Day one configurations

--- a/README.md
+++ b/README.md
@@ -16,14 +16,27 @@ Pre-requisites: `oc`, `jq` and `git` should be pre-installed and you should be l
 
 ```bash
 # STEP 1: Install Dev Spaces next
-git submodule init && git submodule update && git -C devspaces checkout devspaces-3-rhel-8 &&
-cd devspaces/product && ./installDevSpacesFromLatestIIB.sh --next && \
-oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]' # re-enable default catalog sources
+DSC_HOME=/home/user/.dsc
+TEMP_DIR="$(mktemp -d)"
+DSC_VERSION="3.4.0"
+DSC_ARCH="linux-x64"
+DSC_TGZ="devspaces-${DSC_VERSION}-dsc-${DSC_ARCH}.tar.gz"
+DSC_TGZ_URL="https://github.com/redhat-developer/devspaces-chectl/releases/download/${DSC_VERSION}-GA-dsc-assets/${DSC_TGZ}"
+
+cd "${TEMP_DIR}"
+curl -sSLO "${DSC_TGZ_URL}"
+tar -zxvf "${DSC_TGZ}"
+mv dsc "${DSC_HOME}"
+PATH=${PATH}:${DSC_HOME}/bin
+rm "${DSC_TGZ}"
+cd -
+
+dsc server:deploy --olm-channel=fast
 ```
 
 | :ship: NOTE                                                                                        |
 |-------------------------------------------------------------------------------------------------------|
-| If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `./installDevSpacesFromLatestIIB.sh --latest`.|
+| If you want to install the **latest** stable release-in-progress (instead of the **next** CI build), you can use `dsc server:deploy`.|
 
 ```bash
 # STEP 2: Day one configurations


### PR DESCRIPTION
Update the instructions to use the new `dsc server:deploy --olm-channel=fast` command to deploy Dev Spaces next.

Ref: https://issues.redhat.com/browse/CRW-3877